### PR TITLE
Separated group and application label alignment

### DIFF
--- a/package/contents/config/main.xml
+++ b/package/contents/config/main.xml
@@ -89,6 +89,10 @@
 			<!-- enum: left, center, right -->
 			<default>left</default>
 		</entry>
+		<entry name="groupLabelAlignment" type="string">
+			<!-- enum: left, center, right -->
+			<default>left</default>
+		</entry>
 		<entry name="appDescription" type="string">
 			<!-- enum: hidden, after, below -->
 			<default>after</default>

--- a/package/contents/ui/AppletConfig.qml
+++ b/package/contents/ui/AppletConfig.qml
@@ -118,6 +118,17 @@ Item {
 			return Text.AlignLeft
 		}
 	}
+	readonly property int groupLabelAlignment: {
+		var val = plasmoid.configuration.groupLabelAlignment
+		if (val === 'center') {
+			return Text.AlignHCenter
+		} else if (val === 'right') {
+			return Text.AlignRight
+		} else { // left
+			return Text.AlignLeft
+		}
+	}
+	
 	// App Description Enum (hidden, after, below)
 	readonly property bool appDescriptionVisible: plasmoid.configuration.appDescription !== 'hidden'
 	readonly property bool appDescriptionBelow: plasmoid.configuration.appDescription == 'below'

--- a/package/contents/ui/TileItemView.qml
+++ b/package/contents/ui/TileItemView.qml
@@ -21,7 +21,7 @@ Rectangle {
 	readonly property int mediumIconSize: 72 * PlasmaCore.Units.devicePixelRatio
 	readonly property int largeIconSize: 96 * PlasmaCore.Units.devicePixelRatio
 
-	readonly property int tileLabelAlignment: config.tileLabelAlignment
+	readonly property int labelAlignment: appObj.isGroup ? config.groupLabelAlignment : config.tileLabelAlignment
 
 	property bool hovered: false
 
@@ -89,7 +89,7 @@ Rectangle {
 		anchors.left: parent.left
 		anchors.right: parent.right
 		wrapMode: Text.Wrap
-		horizontalAlignment: tileLabelAlignment
+		horizontalAlignment: labelAlignment
 		verticalAlignment: Text.AlignBottom
 		width: parent.width
 		renderType: Text.QtRendering // Fix pixelation when scaling. Plasma.Label uses NativeRendering.

--- a/package/contents/ui/config/ConfigGeneral.qml
+++ b/package/contents/ui/config/ConfigGeneral.qml
@@ -174,7 +174,15 @@ Kirigami.FormLayout {
 			{ value: "right", text: i18n("Right") },
 		]
 	}
-
+	LibConfig.ComboBox {
+		configKey: "groupLabelAlignment"
+		Kirigami.FormData.label: i18n("Group Text Alignment")
+		model: [
+			{ value: "left", text: i18n("Left") },
+			{ value: "center", text: i18n("Center") },
+			{ value: "right", text: i18n("Right") },
+		]
+	}
 
 
 

--- a/package/metadata.desktop
+++ b/package/metadata.desktop
@@ -1,5 +1,5 @@
 [Desktop Entry]
-Name=Tiled Menu
+Name=Tiled Menu Dev
 Comment=A menu based on Windows 10's Start Menu.
 
 Type=Service
@@ -11,7 +11,7 @@ X-Plasma-MainScript=ui/Main.qml
 
 X-KDE-PluginInfo-Author=Chris Holland
 X-KDE-PluginInfo-Email=zrenfire@gmail.com
-X-KDE-PluginInfo-Name=com.github.zren.tiledmenu
+X-KDE-PluginInfo-Name=com.github.zren.tiledmenudev
 X-KDE-PluginInfo-Version=43
 X-KDE-PluginInfo-Website=https://github.com/Zren/plasma-applet-tiledmenu
 X-KDE-PluginInfo-KdeStoreId=1160672


### PR DESCRIPTION
Added a new setting that allows you to separately set the alignment of group labels to provide an extra customization option.

**Example**: group tile left, application tile centre
![Screenshot_20220320_123429](https://user-images.githubusercontent.com/43019560/159144324-3459ec0e-0532-4d05-b9ab-342dd513aaa2.png)

