### PR TITLE
Label Alignments, Single Tile Tooltips

### DIFF
--- a/package/contents/config/main.xml
+++ b/package/contents/config/main.xml
@@ -89,6 +89,10 @@
 			<!-- enum: left, center, right -->
 			<default>left</default>
 		</entry>
+		<entry name="groupLabelAlignment" type="string">
+			<!-- enum: left, center, right -->
+			<default>left</default>
+		</entry>
 		<entry name="appDescription" type="string">
 			<!-- enum: hidden, after, below -->
 			<default>after</default>

--- a/package/contents/ui/AppletConfig.qml
+++ b/package/contents/ui/AppletConfig.qml
@@ -118,6 +118,17 @@ Item {
 			return Text.AlignLeft
 		}
 	}
+	readonly property int groupLabelAlignment: {
+		var val = plasmoid.configuration.groupLabelAlignment
+		if (val === 'center') {
+			return Text.AlignHCenter
+		} else if (val === 'right') {
+			return Text.AlignRight
+		} else { // left
+			return Text.AlignLeft
+		}
+	}
+	
 	// App Description Enum (hidden, after, below)
 	readonly property bool appDescriptionVisible: plasmoid.configuration.appDescription !== 'hidden'
 	readonly property bool appDescriptionBelow: plasmoid.configuration.appDescription == 'below'

--- a/package/contents/ui/TileItem.qml
+++ b/package/contents/ui/TileItem.qml
@@ -1,4 +1,5 @@
 import QtQuick 2.2
+import QtQuick.Controls 2.0 as QQC2
 import org.kde.plasma.core 2.0 as PlasmaCore
 
 Item {
@@ -113,6 +114,15 @@ Item {
 			Drag.drop() // Breaks QML context.
 			// We need to use callLater to call functions after Drag.drop().
 		}
+	}
+
+	QQC2.ToolTip {
+		id: control
+		visible: tileItemView.hovered && !(dragActive || contextMenu.opened) && appObj.tile.w == 1 && appObj.tile.h == 1
+		text: appObj.labelText
+		delay: 0
+		x: parent.width + rightPadding
+		y: (parent.height - height) / 2
 	}
 
 	Loader {

--- a/package/contents/ui/TileItemView.qml
+++ b/package/contents/ui/TileItemView.qml
@@ -21,7 +21,7 @@ Rectangle {
 	readonly property int mediumIconSize: 72 * PlasmaCore.Units.devicePixelRatio
 	readonly property int largeIconSize: 96 * PlasmaCore.Units.devicePixelRatio
 
-	readonly property int tileLabelAlignment: config.tileLabelAlignment
+	readonly property int labelAlignment: appObj.isGroup ? config.groupLabelAlignment : config.tileLabelAlignment
 
 	property bool hovered: false
 
@@ -89,7 +89,7 @@ Rectangle {
 		anchors.left: parent.left
 		anchors.right: parent.right
 		wrapMode: Text.Wrap
-		horizontalAlignment: tileLabelAlignment
+		horizontalAlignment: labelAlignment
 		verticalAlignment: Text.AlignBottom
 		width: parent.width
 		renderType: Text.QtRendering // Fix pixelation when scaling. Plasma.Label uses NativeRendering.

--- a/package/contents/ui/config/ConfigGeneral.qml
+++ b/package/contents/ui/config/ConfigGeneral.qml
@@ -174,7 +174,15 @@ Kirigami.FormLayout {
 			{ value: "right", text: i18n("Right") },
 		]
 	}
-
+	LibConfig.ComboBox {
+		configKey: "groupLabelAlignment"
+		Kirigami.FormData.label: i18n("Group Text Alignment")
+		model: [
+			{ value: "left", text: i18n("Left") },
+			{ value: "center", text: i18n("Center") },
+			{ value: "right", text: i18n("Right") },
+		]
+	}
 
 
 


### PR DESCRIPTION
- Added a new setting that allows you to separately set the alignment of group labels to provide an extra customization option.
- Added tooltips when hovering over a 1x1 tile ([issue #95](https://github.com/Zren/plasma-applet-tiledmenu/issues/95))

Alignment example: group tile left, application tile centre
![image](https://user-images.githubusercontent.com/43019560/159634879-dc981773-396a-4351-9a53-1e80a77bf3df.png)

Apologies for the duplication, had an issue with my pull requests. I also meant to save these features on two separate branches and make two pull requests but accidentally committed prior to branching. Early days of contributing to projects :)