### PR TITLE
Tile Desktop Action fix

### DIFF
--- a/package/contents/ui/AppContextMenu.qml
+++ b/package/contents/ui/AppContextMenu.qml
@@ -86,7 +86,7 @@ Item {
 			}
 	
 			// // https://github.com/KDE/plasma-desktop/blob/master/applets/taskmanager/package/contents/ui/ContextMenu.qml#L75
-			function addActionList(actionList, listModel, index) {
+			function addActionList(actionList, listModel, index, isTileGridModel = false) {
 				// .desktop file Exec actions
 				// ------
 				// Pin to Taskbar / Desktop / Panel
@@ -105,7 +105,11 @@ Item {
 					menuItem.section = actionItem.type == "title"
 					menuItem.icon = actionItem.icon ? actionItem.icon : null
 					menuItem.clicked.connect(function() {
-						listModel.triggerIndexAction(index, actionItem.actionId, actionItem.actionArgument)
+						if (isTileGridModel) {
+							listModel.trigger(index, actionItem.actionId, actionItem.actionArgument)
+						} else {
+							listModel.triggerIndexAction(index, actionItem.actionId, actionItem.actionArgument)
+						}
 					})
 
 					//--- Overrides

--- a/package/contents/ui/AppObject.qml
+++ b/package/contents/ui/AppObject.qml
@@ -47,7 +47,7 @@ QtObject {
 	function addActionList(menu) {
 		if (hasActionList()) {
 			var actionList = getActionList()
-			menu.addActionList(actionList, appsModel.tileGridModel, appObj.app.indexInModel)
+			menu.addActionList(actionList, appsModel.tileGridModel, appObj.app.indexInModel, true)
 		}
 	}
 


### PR DESCRIPTION
- Quick fix for Desktop Actions triggered from Tile context menus crashing tiledmenu/plasmashell under Plasma 5.27.0.