### PR TITLE
Changed implicit onFoo Connection properties to functions

### DIFF
--- a/package/contents/ui/AppObject.qml
+++ b/package/contents/ui/AppObject.qml
@@ -60,7 +60,7 @@ QtObject {
 	}
 	property Connections tileGridConnection: Connections {
 		target: tileGrid
-		onTileModelChanged: {
+		function onTileModelChanged() {
 			if (appObj.isGroup) {
 				appObj.groupRectChanged()
 			}

--- a/package/contents/ui/KickerListView.qml
+++ b/package/contents/ui/KickerListView.qml
@@ -26,13 +26,13 @@ ListView {
 	// currentIndex: 0
 	// Connections {
 	// 	target: appsModel.allAppsModel
-	// 	onRefreshing: {
+	// 	function onRefreshing() {
 	// 		console.log('appsList.onRefreshing')
 	// 		appsList.model = []
 	// 		// console.log('search.results.onRefreshed')
 	// 		appsList.currentIndex = 0
 	// 	}
-	// 	onRefreshed: {
+	// 	function onRefreshed() {
 	// 		console.log('appsList.onRefreshed')
 	// 		// appsList.model = appsModel.allAppsList
 	// 		appsList.model = appsModel.allAppsList

--- a/package/contents/ui/MenuListItem.qml
+++ b/package/contents/ui/MenuListItem.qml
@@ -31,7 +31,7 @@ AppToolButton {
 	property var iconInstance: modelListPopulated && listView.model.list[index] ? listView.model.list[index].icon : ""
 	Connections {
 		target: listView.model
-		onRefreshed: {
+		function onRefreshed() {
 			// We need to manually trigger an update when we update the model without replacing the list.
 			// Otherwise the icon won't be in sync.
 			itemDelegate.iconInstance = listView.model.list[index] ? listView.model.list[index].icon : ""

--- a/package/contents/ui/SearchResultsList.qml
+++ b/package/contents/ui/SearchResultsList.qml
@@ -21,12 +21,12 @@ KickerListView { // RunnerResultsList
 
 	Connections {
 		target: search.results
-		onRefreshing: {
+		function onRefreshing() {
 			searchResultsList.model = []
 			// console.log('search.results.onRefreshed')
 			searchResultsList.currentIndex = 0
 		}
-		onRefreshed: {
+		function onRefreshed() {
 			// console.log('search.results.onRefreshed')
 			searchResultsList.model = search.results
 			// if (searchResultsList.verticalLayoutDirection == Qt.BottomToTop) {

--- a/package/contents/ui/SearchResultsView.qml
+++ b/package/contents/ui/SearchResultsView.qml
@@ -100,7 +100,7 @@ GridLayout {
 
 		Connections {
 			target: searchResultsView
-			onFilterViewOpenChanged: {
+			function onFilterViewOpenChanged() {
 				if (searchResultsView.filterViewOpen) {
 					searchResultsViewStackView.push(searchFiltersViewScrollView)
 				} else {

--- a/package/contents/ui/SearchView.qml
+++ b/package/contents/ui/SearchView.qml
@@ -17,7 +17,7 @@ Item {
 
 	Connections {
 		target: search
-		onIsSearchingChanged: {
+		function onIsSearchingChanged() {
 			if (search.isSearching) {
 				searchView.showSearchView()
 			}
@@ -104,7 +104,7 @@ Item {
 
 			Connections {
 				target: search
-				onQueryChanged: {
+				function onQueryChanged() {
 					if (search.query.length > 0 && stackView.currentItem != searchResultsView) {
 						stackView.push(searchResultsView, true)
 					}

--- a/package/contents/ui/TileEditorColorGroup.qml
+++ b/package/contents/ui/TileEditorColorGroup.qml
@@ -33,7 +33,7 @@ TileEditorGroupBox {
 	Connections {
 		target: appObj
 
-		onTileChanged: {
+		function onTileChanged() {
 			if (key && tile) {
 				colorField.updateOnChange = false
 				colorField.text = appObj.tile[key] || ''

--- a/package/contents/ui/TileEditorField.qml
+++ b/package/contents/ui/TileEditorField.qml
@@ -28,7 +28,7 @@ TileEditorGroupBox {
 	Connections {
 		target: appObj
 
-		onTileChanged: {
+		function onTileChanged() {
 			if (checkedKey && tile) {
 				tileEditorField.updateOnChange = false
 				tileEditorField.checked = typeof appObj.tile[checkedKey] !== "undefined" ? appObj.tile[checkedKey] : checkedDefault
@@ -58,7 +58,7 @@ TileEditorGroupBox {
 			Connections {
 				target: appObj
 
-				onTileChanged: {
+				function onTileChanged() {
 					if (key && tile) {
 						textField.updateOnChange = false
 						textField.text = appObj.tile[key] || ''

--- a/package/contents/ui/TileEditorPresetTiles.qml
+++ b/package/contents/ui/TileEditorPresetTiles.qml
@@ -124,7 +124,7 @@ TileEditorGroupBox {
 	Connections {
 		target: appObj
 
-		onAppUrlChanged: {
+		function onAppUrlChanged() {
 			logger.debug('onAppUrlChanged', appObj.appUrl)
 			tileEditorPresetTiles.checkIfRecognizedLauncher()
 		}

--- a/package/contents/ui/TileEditorSpinBox.qml
+++ b/package/contents/ui/TileEditorSpinBox.qml
@@ -20,7 +20,7 @@ PlasmaComponents3.SpinBox {
 	Connections {
 		target: appObj
 
-		onTileChanged: {
+		function onTileChanged() {
 			if (key && tile) {
 				spinBox.updateOnChange = false
 				spinBox.value = appObj.tile[key] || 0

--- a/package/contents/ui/TileEditorView.qml
+++ b/package/contents/ui/TileEditorView.qml
@@ -165,7 +165,7 @@ ColumnLayout {
 	Connections {
 		target: stackView
 
-		onCurrentItemChanged: {
+		function onCurrentItemChanged() {
 			if (stackView.currentItem != tileEditorView) {
 				tileEditorView.resetView()
 			}
@@ -176,7 +176,7 @@ ColumnLayout {
 	Connections {
 		target: config.tileModel
 
-		onLoaded: {
+		function onLoaded() {
 			// Base64JsonString.save() will create a new JavaScript array [],
 			// and our current tile {} reference will be incorrect, which breaks the tile editor.
 			// We could keep a reference to the tile's index in the array, and make sure

--- a/package/contents/ui/lib/ConfigAdvanced.qml
+++ b/package/contents/ui/lib/ConfigAdvanced.qml
@@ -301,7 +301,7 @@ ColumnLayout {
 
 	Connections {
 		target: configDefaults
-		onUpdated: {
+		function onUpdated() {
 			var keys = configTableModel.keys
 			// Assume the default main.xml's order and plasmoid.configuration is the same (we probably shouldn't).
 			for (var i = 0; i < keys.length; i++) {
@@ -330,7 +330,7 @@ ColumnLayout {
 
 	Connections {
 		target: plasmoid.configuration
-		onValueChanged: {
+		function onValueChanged() {
 			var keyIndex = configTableModel.keys.indexOf(key)
 			if (keyIndex >= 0) {
 				configTableModel.setProperty(keyIndex, 'value', value)


### PR DESCRIPTION
When I ran `plasmashell --replace` in my terminal, I noticed that the following deprecation warning was being spammed because of the tiled menu:

```
QML Connections: Implicitly defined onFoo properties in Connections are deprecated. Use this syntax instead: function onFoo(<arguments>) { ... }
```

This is just a fix to use the new syntax.