### PR TITLE
Fix text over icon

### DIFF
--- a/package/contents/ui/SidebarItem.qml
+++ b/package/contents/ui/SidebarItem.qml
@@ -10,11 +10,12 @@ FlatButton {
 	expanded: sidebarMenu ? sidebarMenu.open : false
 	labelVisible: expanded
 	property bool closeOnClick: true
+	property string tooltipText: ""
 
 	QQC2.ToolTip {
 		id: control
 		visible: sidebarItem.hovered && !sidebarItem.expanded
-		text: sidebarItem.text
+		text: sidebarItem.tooltipText
 		delay: 0
 		x: parent.width + rightPadding
 		y: (parent.height - height) / 2

--- a/package/contents/ui/SidebarItem.qml
+++ b/package/contents/ui/SidebarItem.qml
@@ -15,7 +15,7 @@ FlatButton {
 	QQC2.ToolTip {
 		id: control
 		visible: sidebarItem.hovered && !sidebarItem.expanded
-		text: sidebarItem.tooltipText
+		text: sidebarItem.tooltipText == "" ? sidebarItem.text : sidebarItem.tooltipText
 		delay: 0
 		x: parent.width + rightPadding
 		y: (parent.height - height) / 2

--- a/package/contents/ui/SidebarView.qml
+++ b/package/contents/ui/SidebarView.qml
@@ -50,20 +50,20 @@ Item {
 
 			SidebarViewButton {
 				appletIconName: "view-tilesonly"
-				text: i18n("Tiles Only")
+				tooltipText: i18n("Tiles Only")
 				onClicked: searchView.showTilesOnly()
 				checked: searchView.showingOnlyTiles
 				visible: checked || plasmoid.configuration.defaultAppListView == 'TilesOnly'
 			}
 			SidebarViewButton {
 				appletIconName: "view-list-alphabetically"
-				text: i18n("Alphabetical")
+				tooltipText: i18n("Alphabetical")
 				onClicked: appsView.showAppsAlphabetically()
 				checked: searchView.showingAppsAlphabetically
 			}
 			SidebarViewButton {
 				appletIconName: 'view-list-categorically'
-				text: i18n("Categories")
+				tooltipText: i18n("Categories")
 				onClicked:  appsView.showAppsCategorically()
 				checked: searchView.showingAppsCategorically
 			}


### PR DESCRIPTION
Fixes the issue logged here: https://github.com/Zren/plasma-applet-tiledmenu/issues/166

Instead of setting the item's text (which we wouldn't ever show) we will just set its tooltip text.