### PR TITLE
Add the ability to control whether the app should perform its own int…

### DIFF
--- a/package/contents/config/main.xml
+++ b/package/contents/config/main.xml
@@ -133,6 +133,11 @@
 			<default>36</default>
 		</entry>
 
+		<entry name="useSystemScaling" type="bool">
+		<label>Whether to rely on the system to perform DPI scaling, or do it ourselves.</label>
+			<default>true</default>
+		</entry>
+
 		<!-- Removed v28
 		<entry name="favoriteApps" type="StringList">
 			<label>List of general favorites. Supported values are menu id's (usually .desktop file names), special URLs that expand into default applications (e.g. preferred://browser), document URLs and KPeople contact URIs.</label>

--- a/package/contents/ui/AppletConfig.qml
+++ b/package/contents/ui/AppletConfig.qml
@@ -10,16 +10,20 @@ Item {
 		return c2
 	}
 
+	//--- Miscellaneous
+	readonly property bool useSystemScaling: plasmoid.configuration.useSystemScaling
+	readonly property real scaleFactor: useSystemScaling ? 1.0 : Screen.devicePixelRatio
+
 	//--- Sizes
-	readonly property int panelIconSize: 24 * Screen.devicePixelRatio
-	readonly property int flatButtonSize: plasmoid.configuration.sidebarButtonSize * Screen.devicePixelRatio
-	readonly property int flatButtonIconSize: plasmoid.configuration.sidebarIconSize * Screen.devicePixelRatio
+	readonly property int panelIconSize: 24 * scaleFactor
+	readonly property int flatButtonSize: plasmoid.configuration.sidebarButtonSize * scaleFactor
+	readonly property int flatButtonIconSize: plasmoid.configuration.sidebarIconSize * scaleFactor
 	readonly property int sidebarWidth: flatButtonSize
-	readonly property int sidebarMinOpenWidth: 200 * Screen.devicePixelRatio
-	readonly property int sidebarRightMargin: 4 * Screen.devicePixelRatio
-	readonly property int sidebarPopupButtonSize: plasmoid.configuration.sidebarPopupButtonSize * Screen.devicePixelRatio
-	readonly property int appListWidth: plasmoid.configuration.appListWidth * Screen.devicePixelRatio
-	readonly property int tileEditorMinWidth: Math.max(350, 350 * Screen.devicePixelRatio)
+	readonly property int sidebarMinOpenWidth: 200 * scaleFactor
+	readonly property int sidebarRightMargin: 4 * scaleFactor
+	readonly property int sidebarPopupButtonSize: plasmoid.configuration.sidebarPopupButtonSize * scaleFactor
+	readonly property int appListWidth: plasmoid.configuration.appListWidth * scaleFactor
+	readonly property int tileEditorMinWidth: Math.max(350, 350 * scaleFactor)
 	readonly property int minimumHeight: flatButtonSize * 5 // Issue #125
 
 	property bool showSearch: false
@@ -40,22 +44,22 @@ Item {
 	readonly property int cellBoxUnits: 80
 	readonly property int cellMarginUnits: plasmoid.configuration.tileMargin
 	readonly property int cellSizeUnits: cellBoxUnits - cellMarginUnits*2
-	readonly property int cellSize: cellSizeUnits * tileScale * Screen.devicePixelRatio
-	readonly property real cellMargin: cellMarginUnits * tileScale * Screen.devicePixelRatio
+	readonly property int cellSize: cellSizeUnits * tileScale * scaleFactor
+	readonly property real cellMargin: cellMarginUnits * tileScale * scaleFactor
 	readonly property real cellPushedMargin: cellMargin * 2
 	readonly property int cellBoxSize: cellMargin + cellSize + cellMargin
 	readonly property int tileGridWidth: plasmoid.configuration.favGridCols * cellBoxSize
 
-	readonly property int favCellWidth: 60 * Screen.devicePixelRatio
-	readonly property int favCellPushedMargin: 5 * Screen.devicePixelRatio
-	readonly property int favCellPadding: 3 * Screen.devicePixelRatio
+	readonly property int favCellWidth: 60 * scaleFactor
+	readonly property int favCellPushedMargin: 5 * scaleFactor
+	readonly property int favCellPadding: 3 * scaleFactor
 	readonly property int favColWidth: ((favCellWidth + favCellPadding * 2) * 2) // = 132 (Medium Size)
-	readonly property int favViewDefaultWidth: (favColWidth * 3) * Screen.devicePixelRatio
-	readonly property int favSmallIconSize: 32 * Screen.devicePixelRatio
-	readonly property int favMediumIconSize: 72 * Screen.devicePixelRatio
+	readonly property int favViewDefaultWidth: (favColWidth * 3) * scaleFactor
+	readonly property int favSmallIconSize: 32 * scaleFactor
+	readonly property int favMediumIconSize: 72 * scaleFactor
 	readonly property int favGridWidth: (plasmoid.configuration.favGridCols/2) * favColWidth
 
-	readonly property int searchFieldHeight: plasmoid.configuration.searchFieldHeight * Screen.devicePixelRatio
+	readonly property int searchFieldHeight: plasmoid.configuration.searchFieldHeight * scaleFactor
 
 	readonly property int popupWidth: {
 		if (plasmoid.configuration.fullscreen) {
@@ -69,7 +73,7 @@ Item {
 			return Screen.desktopAvailableHeight
 		} else {
 			// implicit Math.floor() when cast as int
-			var dPR = Screen.devicePixelRatio
+			var dPR = scaleFactor
 			var pH3 = plasmoid.configuration.popupHeight
 			var pH4 = pH3 * dPR
 			var pH5 = Math.floor(pH4)
@@ -78,7 +82,7 @@ Item {
 		}
 	}
 	
-	readonly property int menuItemHeight: plasmoid.configuration.menuItemHeight * Screen.devicePixelRatio
+	readonly property int menuItemHeight: plasmoid.configuration.menuItemHeight * scaleFactor
 	
 	readonly property int searchFilterRowHeight: {
 		if (plasmoid.configuration.appListWidth >= 310) {

--- a/package/contents/ui/FlatButton.qml
+++ b/package/contents/ui/FlatButton.qml
@@ -21,7 +21,7 @@ QQC2.ToolButton {
 
 	// http://doc.qt.io/qt-5/qt.html#Edge-enum
 	property int checkedEdge: 0 // 0 = all edges
-	property int checkedEdgeWidth: 2 * Screen.devicePixelRatio
+	property int checkedEdgeWidth: 2 * config.scaleFactor
 
 	property int buttonHeight: config.flatButtonSize
 	property int iconSize: config.flatButtonIconSize
@@ -56,7 +56,7 @@ QQC2.ToolButton {
 	// 	Item {
 	// 		id: spacingItem
 	// 		Layout.fillHeight: true
-	// 		implicitWidth: 4 * Screen.devicePixelRatio
+	// 		implicitWidth: 4 * config.scaleFactor
 	// 		visible: control.labelVisible
 
 	// 		// Rectangle { border.color: "#f00"; anchors.fill: parent; border.width: 1; color: "transparent"; }

--- a/package/contents/ui/HoverOutlineEffect.qml
+++ b/package/contents/ui/HoverOutlineEffect.qml
@@ -9,7 +9,7 @@ import Qt5Compat.GraphicalEffects as QtGraphicalEffects
 
 Item {
 	id: hoverOutlineEffect
-	property int hoverOutlineSize: 1 * Screen.devicePixelRatio
+	property int hoverOutlineSize: 1 * config.scaleFactor
 	property int hoverRadius: 40
 	property int pressedRadius: hoverRadius
 	property bool useOutlineMask: true

--- a/package/contents/ui/JumpToSectionView.qml
+++ b/package/contents/ui/JumpToSectionView.qml
@@ -26,9 +26,9 @@ GridView {
 
 	property int buttonSize: {
 		if (squareView) {
-			return 70 * Screen.devicePixelRatio
+			return 70 * config.scaleFactor
 		} else {
-			return 36 * Screen.devicePixelRatio
+			return 36 * config.scaleFactor
 		}
 	}
 

--- a/package/contents/ui/KickerListView.qml
+++ b/package/contents/ui/KickerListView.qml
@@ -13,7 +13,7 @@ ListView {
 
 	property bool showItemUrl: true
 	property bool showDesktopFileUrl: false
-	property int iconSize: 36 * Screen.devicePixelRatio
+	property int iconSize: 36 * config.scaleFactor
 
 	section.delegate: KickerSectionHeader {}
 

--- a/package/contents/ui/LauncherIcon.qml
+++ b/package/contents/ui/LauncherIcon.qml
@@ -84,6 +84,10 @@ MouseArea {
 	DragAndDrop.DropArea {
 		id: dropArea
 		anchors.fill: parent
+
+		onDragEnter: {
+			dragHoverTimer.restart()
+		}
 	}
 
 	onContainsMouseChanged: {

--- a/package/contents/ui/SearchField.qml
+++ b/package/contents/ui/SearchField.qml
@@ -23,7 +23,7 @@ PlasmaComponents3.TextField {
 	}
 	property int topMargin: 0
 	property int bottomMargin: 0
-	property int defaultFontSize: 16 * Screen.devicePixelRatio // Not the same as pointSize=16
+	property int defaultFontSize: 16 * config.scaleFactor // Not the same as pointSize=16
 	property int styleMaxFontSize: height - topMargin - bottomMargin
 	font.pixelSize: Math.min(defaultFontSize, styleMaxFontSize)
 

--- a/package/contents/ui/SearchStackView.qml
+++ b/package/contents/ui/SearchStackView.qml
@@ -9,8 +9,8 @@ QQC2.StackView {
 
 	property int zoomDuration: 250
 	property int zoomDelta: 100
-	property real zoomedInRatio: Math.max(1, stackView.width + zoomDelta * Screen.devicePixelRatio) / stackView.width
-	property real zoomedOutRatio: Math.max(1, stackView.width - zoomDelta * Screen.devicePixelRatio) / stackView.width
+	property real zoomedInRatio: Math.max(1, stackView.width + zoomDelta * config.scaleFactor) / stackView.width
+	property real zoomedOutRatio: Math.max(1, stackView.width - zoomDelta * config.scaleFactor) / stackView.width
 
 	// readonly property var noTransition: StackViewDelegate {}
 

--- a/package/contents/ui/SidebarMenuShadows.qml
+++ b/package/contents/ui/SidebarMenuShadows.qml
@@ -1,7 +1,7 @@
 import QtQuick
 
 Item {
-	property int dropShadowSize: 4 * Screen.devicePixelRatio
+	property int dropShadowSize: 4 * config.scaleFactor
 	property int roundShadowHack: dropShadowSize/2 // "dropShadowSize/2" draws enough to fool the eye.
 	Rectangle {
 		id: topShadow

--- a/package/contents/ui/SidebarView.qml
+++ b/package/contents/ui/SidebarView.qml
@@ -73,7 +73,7 @@ Item {
 			// 	onClicked: searchResultsView.showDefaultSearch()
 			// 	// checked: stackView.currentItem == searchResultsView
 			// 	// checkedEdge: Qt.RightEdge
-			// 	// checkedEdgeWidth: 4 * Screen.devicePixelRatio // Twice as thick as normal
+			// 	// checkedEdgeWidth: 4 * config.scaleFactor // Twice as thick as normal
 			// }
 		}
 		ColumnLayout {

--- a/package/contents/ui/SidebarViewButton.qml
+++ b/package/contents/ui/SidebarViewButton.qml
@@ -11,7 +11,7 @@ SidebarItem {
 	readonly property string appletIconFilename: appletIconName ? Qt.resolvedUrl("../icons/" + appletIconName + ".svg") : ""
 
 	checkedEdge: Qt.LeftEdge
-	checkedEdgeWidth: 4 * Screen.devicePixelRatio // Twice as thick as normal
+	checkedEdgeWidth: 4 * config.scaleFactor // Twice as thick as normal
 
 	Kirigami.Icon {
 		id: icon

--- a/package/contents/ui/TileEditorColorField.qml
+++ b/package/contents/ui/TileEditorColorField.qml
@@ -96,7 +96,7 @@ PlasmaComponents3.TextField {
 			id: previewBgMask
 			visible: false
 			anchors.fill: parent
-			border.width: 1 * Screen.devicePixelRatio
+			border.width: 1 * config.scaleFactor
 			border.color: "transparent"
 			radius: width / 2
 		}

--- a/package/contents/ui/TileGrid.qml
+++ b/package/contents/ui/TileGrid.qml
@@ -2,6 +2,7 @@ import QtQuick
 import QtQuick.Controls as QQC2
 import org.kde.kirigami as Kirigami
 import org.kde.plasma.extras as PlasmaExtras
+import org.kde.draganddrop as DragAndDrop
 import "Utils.js" as Utils
 
 DropArea {
@@ -50,31 +51,35 @@ DropArea {
 
 	//--- Drag and Drop events
 	// onContainsDragChanged: console.log('containsDrag', containsDrag)
-	onEntered: {
+	onEntered: drag => {
 		// console.log('onEntered', drag)
 		dragTick(drag)
 	}
-	onPositionChanged: {
+	onPositionChanged: drag => {
 		// console.log('onPositionChanged', drag)
 		dragTick(drag)
 	}
-	onExited: {
+	onExited: drag => {
 		// console.log('onExited')
 		resetDragHover()
 	}
-	onDropped: {
+	onDropped: drop => {
+		dragTick(drop)
 		// console.log('onDropped', drop)
-		if (draggedItem) {
-			tileGrid.moveTile(draggedItem, dropHoverX, dropHoverY)
-			tileGrid.resetDrag()
-			// event.accept(Qt.MoveAction)
-		} else if (addedItem) {
-			addedItem.x = dropHoverX
-			addedItem.y = dropHoverY
-			tileGrid.tileModel.push(addedItem)
-			tileGrid.tileModelChanged()
-			tileGrid.resetDrag()
+		if (canDrop) {
+			if (draggedItem) {
+				tileGrid.moveTile(draggedItem, dropHoverX, dropHoverY)
+				tileGrid.resetDrag()
+				// event.accept(Qt.MoveAction)
+			} else if (addedItem) {
+				addedItem.x = dropHoverX
+				addedItem.y = dropHoverY
+				tileGrid.tileModel.push(addedItem)
+				tileGrid.tileModelChanged()
+				tileGrid.resetDrag()
+			}
 		}
+		tileGrid.resetDrag()
 	}
 
 	// Drag and Drop functions
@@ -177,8 +182,8 @@ DropArea {
 	// https://github.com/qt/qtdeclarative/blob/a4aa8d9ade44d75cb5a1d84bd7c1773fadc73095/src/quick/items/qquickdroparea_p.h#L63
 	function dragTick(event) {
 		// console.log('dragTick', event.x, event.y)
-		var dragX = event.x + scrollView.flickableItem.contentX - dropOffsetX
-		var dragY = event.y + scrollView.flickableItem.contentY - dropOffsetY
+		var dragX = event.x + dropOffsetX
+		var dragY = event.y + dropOffsetY
 		var modelX = Math.floor(dragX / cellBoxSize)
 		var modelY = Math.floor(dragY / cellBoxSize)
 		var globalPoint = popup.mapFromItem(tileGrid, event.x, event.y)

--- a/package/contents/ui/TileGrid.qml
+++ b/package/contents/ui/TileGrid.qml
@@ -7,11 +7,11 @@ import "Utils.js" as Utils
 DropArea {
 	id: tileGrid
 
-	property int cellSize: 60 * Screen.devicePixelRatio
-	property real cellMargin: 3 * Screen.devicePixelRatio
-	property real cellPushedMargin: 6 * Screen.devicePixelRatio
+	property int cellSize: 60 * config.scaleFactor
+	property real cellMargin: 3 * config.scaleFactor
+	property real cellPushedMargin: 6 * config.scaleFactor
 	property int cellBoxSize: cellMargin + cellSize + cellMargin
-	property int hoverOutlineSize: 2 * Screen.devicePixelRatio
+	property int hoverOutlineSize: 2 * config.scaleFactor
 
 	property int minColumns: Math.floor(width / cellBoxSize)
 	property int minRows: Math.floor(height / cellBoxSize)

--- a/package/contents/ui/TileItem.qml
+++ b/package/contents/ui/TileItem.qml
@@ -96,13 +96,13 @@ Item {
 
 	// We use this drag pattern to use the internal drag with events.
 	// https://stackoverflow.com/a/24729837/947742
-	readonly property bool dragActive: tileMouseArea.drag.active
-	onDragActiveChanged: function(dragActive) {
+	property bool dragActive: tileMouseArea.drag.active
+	onDragActiveChanged: {
 		if (dragActive) {
 			// console.log("drag started")
 			// console.log('onDragStarted', JSON.stringify(modelData), index, tileModel.length)
 			tileGrid.startDrag(index)
-			// tileGrid.dropOffsetX = 0
+			tileGrid.dropOffsetX = 0
 			// tileGrid.dropOffsetY = 0
 			tileItem.z = 1
 			Drag.start()

--- a/package/contents/ui/TileItemView.qml
+++ b/package/contents/ui/TileItemView.qml
@@ -16,10 +16,10 @@ Rectangle {
 	}
 	gradient: appObj.backgroundGradient ? tileGradient.createObject(tileItemView) : null
 
-	readonly property int tilePadding: 4 * Screen.devicePixelRatio
-	readonly property int smallIconSize: 32 * Screen.devicePixelRatio
-	readonly property int mediumIconSize: 72 * Screen.devicePixelRatio
-	readonly property int largeIconSize: 96 * Screen.devicePixelRatio
+	readonly property int tilePadding: 4 * config.scaleFactor
+	readonly property int smallIconSize: 32 * config.scaleFactor
+	readonly property int mediumIconSize: 72 * config.scaleFactor
+	readonly property int largeIconSize: 96 * config.scaleFactor
 
 	readonly property int labelAlignment: appObj.isGroup ? config.groupLabelAlignment : config.tileLabelAlignment
 

--- a/package/contents/ui/config/ConfigGeneral.qml
+++ b/package/contents/ui/config/ConfigGeneral.qml
@@ -529,7 +529,8 @@ LibConfig.FormKCM {
 
 
 	//-------------------------------------------------------
-	LibConfig.Heading {
+	// Disabling for now as there appears to be a problem using the TextField.qml file
+	/*LibConfig.Heading {
 		text: i18n("Right Click Menu")
 	}
 	LibConfig.TextField {
@@ -543,6 +544,17 @@ LibConfig.FormKCM {
 	LibConfig.TextField {
 		configKey: 'fileManagerApp'
 		Kirigami.FormData.label: i18n("File Manager")
+	}*/
+
+	//-------------------------------------------------------
+	LibConfig.Heading {
+		text: i18n("Miscellaneous")
+	}
+
+	LibConfig.CheckBox {
+		id: useSystemScalingCheckbox
+		text: i18n("Use system scaling")
+		configKey: 'useSystemScaling'
 	}
 
 }

--- a/package/contents/ui/main.qml
+++ b/package/contents/ui/main.qml
@@ -164,7 +164,7 @@ PlasmoidItem {
 			onTriggered: {
 				if (!plasmoid.configuration.fullscreen) {
 					// Need to Math.ceil when writing to fix (Issue #71)
-					var dPR = Screen.devicePixelRatio
+					var dPR = scaleFactor
 					var pH2 = height / dPR
 					var pH3 = Math.ceil(pH2)
 					// console.log('pH.set', 'dPR='+dPR, 'pH1='+height, 'pH2='+pH2, 'pH3='+pH3)

--- a/package/metadata.json
+++ b/package/metadata.json
@@ -5,9 +5,21 @@
 			{
 				"Email": "zrenfire@gmail.com",
 				"Name": "Chris Holland"
+			},
+			{
+				"Email": "bruce@passioncomputing.com.au",
+				"Name": "Bruce Andrewartha"
+			},
+			{
+				"Email": "wauters.johan@telenet.be",
+				"Name": "Johan Wauters"
+			},
+			{
+				"Email": "infinitesnails@gmail.com",
+				"Name": "Nick Irwin"
 			}
 		],
-		"BugReportUrl": "https://github.com/Zren/plasma-applet-tiledmenu/issues",
+		"BugReportUrl": "https://github.com/nirwin81/plasma-applet-tiledmenu/issues",
 		"Category": "Application Launchers",
 		"Description": "A menu based on Windows 10's Start Menu.",
 		"Description[es]": "Menú basado en el menú de inicio de Windows 10",
@@ -24,7 +36,7 @@
 		"Description[tr]": "Windows 10'un Başlat Menüsü'nü temel alan bir menü.",
 		"Description[zh_TW]": "一個基於 Windows 10 開始功能表的選單。",
 		"Icon": "start-here-kde",
-		"Id": "com.github.zren.tiledmenu",
+		"Id": "com.github.nirwin81.tiledmenu",
 		"License": "GPL-2.0+",
 		"Name": "Tiled Menu",
 		"Name[es]": "Menú con Baldosas",
@@ -40,8 +52,8 @@
 		"Name[sl]": "Meni s ploščicami",
 		"Name[tr]": "Döşeli Menü",
 		"Name[zh_TW]": "方塊磚選單",
-		"Version": "46",
-		"Website": "https://github.com/Zren/plasma-applet-tiledmenu"
+		"Version": "48",
+		"Website": "https://github.com/nirwin81/plasma-applet-tiledmenu"
 	},
 	"X-Plasma-API-Minimum-Version": "6.0",
 	"X-Plasma-Provides": [


### PR DESCRIPTION
Add the ability to control whether the app should perform its own internal dpi scaling (existing behaviour) or rely on 'system scaling'.

In my experience the latter behaves as expected whilst the former scales disproportionately.
I think "Use system scaling" should be the default option (true), but don't want to mess with peoples existing setups, so will leave this to default as false. (though will make it true on my fork)
No idea how this change works on multiple monitors.

Fixes the issue logged here: [https://github.com/Zren/plasma-applet-tiledmenu/issues/176](url)

Additional: Some ConfigGeneral settings were relying on a TextField.qml file that isn't present so I'm disabling those entries for now.