### PR TITLE
Add the ability to control whether the app should perform its own internal scaling or rely on system scaling

### DIFF
--- a/package/contents/config/main.xml
+++ b/package/contents/config/main.xml
@@ -133,6 +133,11 @@
 			<default>36</default>
 		</entry>
 
+		<entry name="useSystemScaling" type="bool">
+		<label>Whether to rely on the system to perform DPI scaling, or do it ourselves.</label>
+			<default>true</default>
+		</entry>
+
 		<!-- Removed v28
 		<entry name="favoriteApps" type="StringList">
 			<label>List of general favorites. Supported values are menu id's (usually .desktop file names), special URLs that expand into default applications (e.g. preferred://browser), document URLs and KPeople contact URIs.</label>

--- a/package/contents/ui/AppletConfig.qml
+++ b/package/contents/ui/AppletConfig.qml
@@ -10,16 +10,20 @@ Item {
 		return c2
 	}
 
+	//--- Miscellaneous
+	readonly property bool useSystemScaling: plasmoid.configuration.useSystemScaling
+	readonly property real scaleFactor: useSystemScaling ? 1.0 : Screen.devicePixelRatio
+
 	//--- Sizes
-	readonly property int panelIconSize: 24 * Screen.devicePixelRatio
-	readonly property int flatButtonSize: plasmoid.configuration.sidebarButtonSize * Screen.devicePixelRatio
-	readonly property int flatButtonIconSize: plasmoid.configuration.sidebarIconSize * Screen.devicePixelRatio
+	readonly property int panelIconSize: 24 * scaleFactor
+	readonly property int flatButtonSize: plasmoid.configuration.sidebarButtonSize * scaleFactor
+	readonly property int flatButtonIconSize: plasmoid.configuration.sidebarIconSize * scaleFactor
 	readonly property int sidebarWidth: flatButtonSize
-	readonly property int sidebarMinOpenWidth: 200 * Screen.devicePixelRatio
-	readonly property int sidebarRightMargin: 4 * Screen.devicePixelRatio
-	readonly property int sidebarPopupButtonSize: plasmoid.configuration.sidebarPopupButtonSize * Screen.devicePixelRatio
-	readonly property int appListWidth: plasmoid.configuration.appListWidth * Screen.devicePixelRatio
-	readonly property int tileEditorMinWidth: Math.max(350, 350 * Screen.devicePixelRatio)
+	readonly property int sidebarMinOpenWidth: 200 * scaleFactor
+	readonly property int sidebarRightMargin: 4 * scaleFactor
+	readonly property int sidebarPopupButtonSize: plasmoid.configuration.sidebarPopupButtonSize * scaleFactor
+	readonly property int appListWidth: plasmoid.configuration.appListWidth * scaleFactor
+	readonly property int tileEditorMinWidth: Math.max(350, 350 * scaleFactor)
 	readonly property int minimumHeight: flatButtonSize * 5 // Issue #125
 
 	property bool showSearch: false
@@ -40,22 +44,22 @@ Item {
 	readonly property int cellBoxUnits: 80
 	readonly property int cellMarginUnits: plasmoid.configuration.tileMargin
 	readonly property int cellSizeUnits: cellBoxUnits - cellMarginUnits*2
-	readonly property int cellSize: cellSizeUnits * tileScale * Screen.devicePixelRatio
-	readonly property real cellMargin: cellMarginUnits * tileScale * Screen.devicePixelRatio
+	readonly property int cellSize: cellSizeUnits * tileScale * scaleFactor
+	readonly property real cellMargin: cellMarginUnits * tileScale * scaleFactor
 	readonly property real cellPushedMargin: cellMargin * 2
 	readonly property int cellBoxSize: cellMargin + cellSize + cellMargin
 	readonly property int tileGridWidth: plasmoid.configuration.favGridCols * cellBoxSize
 
-	readonly property int favCellWidth: 60 * Screen.devicePixelRatio
-	readonly property int favCellPushedMargin: 5 * Screen.devicePixelRatio
-	readonly property int favCellPadding: 3 * Screen.devicePixelRatio
+	readonly property int favCellWidth: 60 * scaleFactor
+	readonly property int favCellPushedMargin: 5 * scaleFactor
+	readonly property int favCellPadding: 3 * scaleFactor
 	readonly property int favColWidth: ((favCellWidth + favCellPadding * 2) * 2) // = 132 (Medium Size)
-	readonly property int favViewDefaultWidth: (favColWidth * 3) * Screen.devicePixelRatio
-	readonly property int favSmallIconSize: 32 * Screen.devicePixelRatio
-	readonly property int favMediumIconSize: 72 * Screen.devicePixelRatio
+	readonly property int favViewDefaultWidth: (favColWidth * 3) * scaleFactor
+	readonly property int favSmallIconSize: 32 * scaleFactor
+	readonly property int favMediumIconSize: 72 * scaleFactor
 	readonly property int favGridWidth: (plasmoid.configuration.favGridCols/2) * favColWidth
 
-	readonly property int searchFieldHeight: plasmoid.configuration.searchFieldHeight * Screen.devicePixelRatio
+	readonly property int searchFieldHeight: plasmoid.configuration.searchFieldHeight * scaleFactor
 
 	readonly property int popupWidth: {
 		if (plasmoid.configuration.fullscreen) {
@@ -69,7 +73,7 @@ Item {
 			return Screen.desktopAvailableHeight
 		} else {
 			// implicit Math.floor() when cast as int
-			var dPR = Screen.devicePixelRatio
+			var dPR = scaleFactor
 			var pH3 = plasmoid.configuration.popupHeight
 			var pH4 = pH3 * dPR
 			var pH5 = Math.floor(pH4)
@@ -78,7 +82,7 @@ Item {
 		}
 	}
 	
-	readonly property int menuItemHeight: plasmoid.configuration.menuItemHeight * Screen.devicePixelRatio
+	readonly property int menuItemHeight: plasmoid.configuration.menuItemHeight * scaleFactor
 	
 	readonly property int searchFilterRowHeight: {
 		if (plasmoid.configuration.appListWidth >= 310) {

--- a/package/contents/ui/FlatButton.qml
+++ b/package/contents/ui/FlatButton.qml
@@ -21,7 +21,7 @@ QQC2.ToolButton {
 
 	// http://doc.qt.io/qt-5/qt.html#Edge-enum
 	property int checkedEdge: 0 // 0 = all edges
-	property int checkedEdgeWidth: 2 * Screen.devicePixelRatio
+	property int checkedEdgeWidth: 2 * config.scaleFactor
 
 	property int buttonHeight: config.flatButtonSize
 	property int iconSize: config.flatButtonIconSize
@@ -56,7 +56,7 @@ QQC2.ToolButton {
 	// 	Item {
 	// 		id: spacingItem
 	// 		Layout.fillHeight: true
-	// 		implicitWidth: 4 * Screen.devicePixelRatio
+	// 		implicitWidth: 4 * config.scaleFactor
 	// 		visible: control.labelVisible
 
 	// 		// Rectangle { border.color: "#f00"; anchors.fill: parent; border.width: 1; color: "transparent"; }

--- a/package/contents/ui/HoverOutlineEffect.qml
+++ b/package/contents/ui/HoverOutlineEffect.qml
@@ -9,7 +9,7 @@ import Qt5Compat.GraphicalEffects as QtGraphicalEffects
 
 Item {
 	id: hoverOutlineEffect
-	property int hoverOutlineSize: 1 * Screen.devicePixelRatio
+	property int hoverOutlineSize: 1 * config.scaleFactor
 	property int hoverRadius: 40
 	property int pressedRadius: hoverRadius
 	property bool useOutlineMask: true

--- a/package/contents/ui/JumpToSectionView.qml
+++ b/package/contents/ui/JumpToSectionView.qml
@@ -26,9 +26,9 @@ GridView {
 
 	property int buttonSize: {
 		if (squareView) {
-			return 70 * Screen.devicePixelRatio
+			return 70 * config.scaleFactor
 		} else {
-			return 36 * Screen.devicePixelRatio
+			return 36 * config.scaleFactor
 		}
 	}
 

--- a/package/contents/ui/KickerListView.qml
+++ b/package/contents/ui/KickerListView.qml
@@ -13,7 +13,7 @@ ListView {
 
 	property bool showItemUrl: true
 	property bool showDesktopFileUrl: false
-	property int iconSize: 36 * Screen.devicePixelRatio
+	property int iconSize: 36 * config.scaleFactor
 
 	section.delegate: KickerSectionHeader {}
 

--- a/package/contents/ui/SearchField.qml
+++ b/package/contents/ui/SearchField.qml
@@ -23,7 +23,7 @@ PlasmaComponents3.TextField {
 	}
 	property int topMargin: 0
 	property int bottomMargin: 0
-	property int defaultFontSize: 16 * Screen.devicePixelRatio // Not the same as pointSize=16
+	property int defaultFontSize: 16 * config.scaleFactor // Not the same as pointSize=16
 	property int styleMaxFontSize: height - topMargin - bottomMargin
 	font.pixelSize: Math.min(defaultFontSize, styleMaxFontSize)
 

--- a/package/contents/ui/SearchStackView.qml
+++ b/package/contents/ui/SearchStackView.qml
@@ -9,8 +9,8 @@ QQC2.StackView {
 
 	property int zoomDuration: 250
 	property int zoomDelta: 100
-	property real zoomedInRatio: Math.max(1, stackView.width + zoomDelta * Screen.devicePixelRatio) / stackView.width
-	property real zoomedOutRatio: Math.max(1, stackView.width - zoomDelta * Screen.devicePixelRatio) / stackView.width
+	property real zoomedInRatio: Math.max(1, stackView.width + zoomDelta * config.scaleFactor) / stackView.width
+	property real zoomedOutRatio: Math.max(1, stackView.width - zoomDelta * config.scaleFactor) / stackView.width
 
 	// readonly property var noTransition: StackViewDelegate {}
 

--- a/package/contents/ui/SidebarMenuShadows.qml
+++ b/package/contents/ui/SidebarMenuShadows.qml
@@ -1,7 +1,7 @@
 import QtQuick
 
 Item {
-	property int dropShadowSize: 4 * Screen.devicePixelRatio
+	property int dropShadowSize: 4 * config.scaleFactor
 	property int roundShadowHack: dropShadowSize/2 // "dropShadowSize/2" draws enough to fool the eye.
 	Rectangle {
 		id: topShadow

--- a/package/contents/ui/SidebarView.qml
+++ b/package/contents/ui/SidebarView.qml
@@ -73,7 +73,7 @@ Item {
 			// 	onClicked: searchResultsView.showDefaultSearch()
 			// 	// checked: stackView.currentItem == searchResultsView
 			// 	// checkedEdge: Qt.RightEdge
-			// 	// checkedEdgeWidth: 4 * Screen.devicePixelRatio // Twice as thick as normal
+			// 	// checkedEdgeWidth: 4 * config.scaleFactor // Twice as thick as normal
 			// }
 		}
 		ColumnLayout {

--- a/package/contents/ui/SidebarViewButton.qml
+++ b/package/contents/ui/SidebarViewButton.qml
@@ -11,7 +11,7 @@ SidebarItem {
 	readonly property string appletIconFilename: appletIconName ? Qt.resolvedUrl("../icons/" + appletIconName + ".svg") : ""
 
 	checkedEdge: Qt.LeftEdge
-	checkedEdgeWidth: 4 * Screen.devicePixelRatio // Twice as thick as normal
+	checkedEdgeWidth: 4 * config.scaleFactor // Twice as thick as normal
 
 	Kirigami.Icon {
 		id: icon

--- a/package/contents/ui/TileEditorColorField.qml
+++ b/package/contents/ui/TileEditorColorField.qml
@@ -96,7 +96,7 @@ PlasmaComponents3.TextField {
 			id: previewBgMask
 			visible: false
 			anchors.fill: parent
-			border.width: 1 * Screen.devicePixelRatio
+			border.width: 1 * config.scaleFactor
 			border.color: "transparent"
 			radius: width / 2
 		}

--- a/package/contents/ui/TileGrid.qml
+++ b/package/contents/ui/TileGrid.qml
@@ -7,11 +7,11 @@ import "Utils.js" as Utils
 DropArea {
 	id: tileGrid
 
-	property int cellSize: 60 * Screen.devicePixelRatio
-	property real cellMargin: 3 * Screen.devicePixelRatio
-	property real cellPushedMargin: 6 * Screen.devicePixelRatio
+	property int cellSize: 60 * config.scaleFactor
+	property real cellMargin: 3 * config.scaleFactor
+	property real cellPushedMargin: 6 * config.scaleFactor
 	property int cellBoxSize: cellMargin + cellSize + cellMargin
-	property int hoverOutlineSize: 2 * Screen.devicePixelRatio
+	property int hoverOutlineSize: 2 * config.scaleFactor
 
 	property int minColumns: Math.floor(width / cellBoxSize)
 	property int minRows: Math.floor(height / cellBoxSize)

--- a/package/contents/ui/TileItemView.qml
+++ b/package/contents/ui/TileItemView.qml
@@ -16,10 +16,10 @@ Rectangle {
 	}
 	gradient: appObj.backgroundGradient ? tileGradient.createObject(tileItemView) : null
 
-	readonly property int tilePadding: 4 * Screen.devicePixelRatio
-	readonly property int smallIconSize: 32 * Screen.devicePixelRatio
-	readonly property int mediumIconSize: 72 * Screen.devicePixelRatio
-	readonly property int largeIconSize: 96 * Screen.devicePixelRatio
+	readonly property int tilePadding: 4 * config.scaleFactor
+	readonly property int smallIconSize: 32 * config.scaleFactor
+	readonly property int mediumIconSize: 72 * config.scaleFactor
+	readonly property int largeIconSize: 96 * config.scaleFactor
 
 	readonly property int labelAlignment: appObj.isGroup ? config.groupLabelAlignment : config.tileLabelAlignment
 

--- a/package/contents/ui/config/ConfigGeneral.qml
+++ b/package/contents/ui/config/ConfigGeneral.qml
@@ -529,7 +529,8 @@ LibConfig.FormKCM {
 
 
 	//-------------------------------------------------------
-	LibConfig.Heading {
+	// Disabling for now as there appears to be a problem using the TextField.qml file
+	/*LibConfig.Heading {
 		text: i18n("Right Click Menu")
 	}
 	LibConfig.TextField {
@@ -543,6 +544,17 @@ LibConfig.FormKCM {
 	LibConfig.TextField {
 		configKey: 'fileManagerApp'
 		Kirigami.FormData.label: i18n("File Manager")
+	}*/
+
+	//-------------------------------------------------------
+	LibConfig.Heading {
+		text: i18n("Miscellaneous")
+	}
+
+	LibConfig.CheckBox {
+		id: useSystemScalingCheckbox
+		text: i18n("Use system scaling")
+		configKey: 'useSystemScaling'
 	}
 
 }

--- a/package/contents/ui/main.qml
+++ b/package/contents/ui/main.qml
@@ -164,7 +164,7 @@ PlasmoidItem {
 			onTriggered: {
 				if (!plasmoid.configuration.fullscreen) {
 					// Need to Math.ceil when writing to fix (Issue #71)
-					var dPR = Screen.devicePixelRatio
+					var dPR = scaleFactor
 					var pH2 = height / dPR
 					var pH3 = Math.ceil(pH2)
 					// console.log('pH.set', 'dPR='+dPR, 'pH1='+height, 'pH2='+pH2, 'pH3='+pH3)


### PR DESCRIPTION
Add the ability to control whether the plasmoid should perform its own internal dpi scaling (existing behaviour) or rely on 'system scaling'.

In my experience the latter behaves as expected whilst the former scales disproportionately.
I think "Use system scaling" should be the default option (true), but don't want to mess with peoples existing setups, so will leave this to default as false. (though will make it true on my fork)
No idea how this change works on multiple monitors.

Fixes the issue logged here: [https://github.com/Zren/plasma-applet-tiledmenu/issues/176](https://github.com/Zren/plasma-applet-tiledmenu/pull/url)

Additional: Some ConfigGeneral settings were relying on a TextField.qml file that isn't present so I'm disabling those entries for now.